### PR TITLE
Add missing modality preprocessing and trainer

### DIFF
--- a/documentation/missing_modalities.md
+++ b/documentation/missing_modalities.md
@@ -1,0 +1,17 @@
+# Handling Missing Modalities
+
+This repository provides a small example on how missing input modalities can be addressed. The
+`MissingModalitiesPreprocessor` fills absent image channels with zeros during preprocessing. A
+corresponding trainer (`nnUNetTrainerModalityPrompt`) wraps the default architecture with simple
+per‑modality prompt encoders. These encoders process each input channel separately before passing
+the result to the standard nnU‑Net network.
+
+Use the new components as follows:
+
+```bash
+nnUNetv2_plan_and_preprocess -d DATASET_ID -c CONFIGURATION -pp MissingModalitiesPreprocessor
+nnUNetv2_train -d DATASET_ID -c CONFIGURATION -tr nnUNetTrainerModalityPrompt
+```
+
+Replace `DATASET_ID` and `CONFIGURATION` with your dataset and configuration name.
+

--- a/nnunetv2/preprocessing/preprocessors/__init__.py
+++ b/nnunetv2/preprocessing/preprocessors/__init__.py
@@ -1,0 +1,5 @@
+from .default_preprocessor import DefaultPreprocessor
+from .missing_modalities_preprocessor import MissingModalitiesPreprocessor
+
+__all__ = ["DefaultPreprocessor", "MissingModalitiesPreprocessor"]
+

--- a/nnunetv2/preprocessing/preprocessors/missing_modalities_preprocessor.py
+++ b/nnunetv2/preprocessing/preprocessors/missing_modalities_preprocessor.py
@@ -1,0 +1,62 @@
+import os
+from typing import List, Union
+import numpy as np
+from batchgenerators.utilities.file_and_folder_operations import load_json
+
+from .default_preprocessor import DefaultPreprocessor
+
+
+class MissingModalitiesPreprocessor(DefaultPreprocessor):
+    """Preprocessor that fills missing image modalities with zeros."""
+
+    def run_case(
+        self,
+        image_files: List[str],
+        seg_file: Union[str, None],
+        plans_manager,
+        configuration_manager,
+        dataset_json: Union[dict, str],
+    ):
+        if isinstance(dataset_json, str):
+            dataset_json = load_json(dataset_json)
+
+        num_modalities = len(dataset_json.get("channel_names", {}))
+
+        # map modality index to file
+        file_map = {}
+        for f in image_files:
+            base = os.path.basename(f)
+            try:
+                idx = int(base.split("_")[-1].split(".")[0])
+            except ValueError:
+                continue
+            file_map[idx] = f
+
+        assert 0 in file_map, "T2 modality (_0000) must be present for every case"
+
+        rw = plans_manager.image_reader_writer_class()
+
+        data_list = []
+        data0, properties = rw.read_images((file_map[0],))
+        data_list.append(data0.astype(np.float32, copy=False))
+        shape = data0.shape[1:]
+
+        if seg_file is not None:
+            seg, _ = rw.read_seg(seg_file)
+        else:
+            seg = None
+
+        for m in range(1, num_modalities):
+            if m in file_map:
+                img, _ = rw.read_images((file_map[m],))
+                img = img.astype(np.float32, copy=False)
+            else:
+                img = np.zeros((1, *shape), dtype=np.float32)
+            data_list.append(img)
+
+        data = np.vstack(data_list)
+        data, seg, properties = self.run_case_npy(
+            data, seg, properties, plans_manager, configuration_manager, dataset_json
+        )
+        return data, seg, properties
+

--- a/nnunetv2/training/network_architecture/__init__.py
+++ b/nnunetv2/training/network_architecture/__init__.py
@@ -1,0 +1,2 @@
+from .modality_prompt_wrapper import ModalityPromptWrapper
+

--- a/nnunetv2/training/network_architecture/modality_prompt_wrapper.py
+++ b/nnunetv2/training/network_architecture/modality_prompt_wrapper.py
@@ -1,0 +1,21 @@
+import torch
+from torch import nn
+
+
+class ModalityPromptWrapper(nn.Module):
+    """Wraps a base segmentation network with per-modality prompt encoders."""
+
+    def __init__(self, base_network: nn.Module, num_modalities: int):
+        super().__init__()
+        self.base_network = base_network
+        self.prompt_encoders = nn.ModuleList(
+            [nn.Sequential(nn.Conv3d(1, 1, 3, padding=1), nn.ReLU(inplace=True)) for _ in range(num_modalities)]
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        prompts = []
+        for m in range(x.shape[1]):
+            prompts.append(self.prompt_encoders[m](x[:, m : m + 1]))
+        x = torch.cat(prompts, dim=1)
+        return self.base_network(x)
+

--- a/nnunetv2/training/nnUNetTrainer/variants/network_architecture/__init__.py
+++ b/nnunetv2/training/nnUNetTrainer/variants/network_architecture/__init__.py
@@ -1,0 +1,10 @@
+from .nnUNetTrainerBN import nnUNetTrainerBN
+from .nnUNetTrainerNoDeepSupervision import nnUNetTrainerNoDeepSupervision
+from .nnUNetTrainerModalityPrompt import nnUNetTrainerModalityPrompt
+
+__all__ = [
+    "nnUNetTrainerBN",
+    "nnUNetTrainerNoDeepSupervision",
+    "nnUNetTrainerModalityPrompt",
+]
+

--- a/nnunetv2/training/nnUNetTrainer/variants/network_architecture/nnUNetTrainerModalityPrompt.py
+++ b/nnunetv2/training/nnUNetTrainer/variants/network_architecture/nnUNetTrainerModalityPrompt.py
@@ -1,0 +1,24 @@
+from nnunetv2.training.nnUNetTrainer.nnUNetTrainer import nnUNetTrainer
+from nnunetv2.training.network_architecture.modality_prompt_wrapper import ModalityPromptWrapper
+
+
+class nnUNetTrainerModalityPrompt(nnUNetTrainer):
+    @staticmethod
+    def build_network_architecture(
+        architecture_class_name: str,
+        arch_init_kwargs: dict,
+        arch_init_kwargs_req_import,
+        num_input_channels: int,
+        num_output_channels: int,
+        enable_deep_supervision: bool = True,
+    ):
+        base_net = nnUNetTrainer.build_network_architecture(
+            architecture_class_name,
+            arch_init_kwargs,
+            arch_init_kwargs_req_import,
+            num_input_channels,
+            num_output_channels,
+            enable_deep_supervision,
+        )
+        return ModalityPromptWrapper(base_net, num_input_channels)
+

--- a/readme.md
+++ b/readme.md
@@ -102,6 +102,7 @@ Additional information:
 - [Intensity Normalization in nnU-Net](documentation/explanation_normalization.md)
 - [Manually editing nnU-Net configurations](documentation/explanation_plans_files.md)
 - [Extending nnU-Net](documentation/extending_nnunet.md)
+- [Handling Missing Modalities](documentation/missing_modalities.md)
 - [What is different in V2?](documentation/changelog.md)
 
 Competitions:


### PR DESCRIPTION
## Summary
- support cases without full set of modalities
- wrap networks with simple prompt encoders
- document how to run the new components

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'batchgenerators')*

------
https://chatgpt.com/codex/tasks/task_e_683f96658a3483269da814bf885f3a20